### PR TITLE
Add in_reploy_to_status_id when client update

### DIFF
--- a/lib/ruboty/adapters/twitter.rb
+++ b/lib/ruboty/adapters/twitter.rb
@@ -16,8 +16,18 @@ module Ruboty
         listen
       end
 
-      def say(body)
-        client.update(body)
+      def say(message)
+        case message
+        when String
+          body = message
+        when Hash
+          body = message[:body]
+          if tweet = message[:original][:tweet]
+            options = { in_reply_to_status_id: tweet.id }
+          end
+        end
+
+        client.update(body, options)
       end
 
       private
@@ -26,7 +36,11 @@ module Ruboty
         stream.user do |tweet|
           case tweet
           when ::Twitter::Tweet
-            robot.receive(body: tweet.text)
+            robot.receive(
+              body: tweet.text,
+              from: tweet.user.screen_name,
+              tweet: tweet
+            )
           end
         end
       end


### PR DESCRIPTION
`Robot#say` には Hash が入ってくるのがほとんどなようなので、それに対応しつつ、 `in_reploy_to_status_id` を差し込むように変更してみました。

https://github.com/r7kamura/ruboty/blob/c7e49393c7364e9fd6c2b4d93545e4dd7155ae3f/lib/ruboty/message.rb#L42-L45

``` ruby
    def reply(body, options = {})
      attributes = { body: body, from: to, to: from, original: original }.merge(options)
      robot.say(attributes)
    end
```
