### PR TITLE
Use tweetstream for StreamingAPI

### DIFF
--- a/ruboty-twitter.gemspec
+++ b/ruboty-twitter.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "mem"
   spec.add_dependency "ruboty"
   spec.add_dependency "twitter", ">= 5.0.0"
+  spec.add_dependency "tweetstream", "~> 2.6.1"
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"
 end


### PR DESCRIPTION
ref https://github.com/sferik/twitter/issues/709

StreamingAPI接続に下記エラーが発生するため、StreamingAPIへの接続には`tweetstrem/tweetstream`を使用するよう変更しました。

`sferik/twitter`のHEADでは修正済みなようなので、次のバージョンが出たらrevertするのが良いかもしれません。
# Error

```
$ be ruboty --dotenv   
Ruboty::Adapters::Twitter#run started
/Users/gin0606/my_app/.bundle/ruby/2.2.0/gems/twitter-5.15.0/lib/twitter/streaming/connection.rb:16:in `initialize': Can't assign requested address - connect(2) for "199.59.148.139" port  (Errno::EADDRNOTAVAIL)
    from /Users/gin0606/my_app/.bundle/ruby/2.2.0/gems/twitter-5.15.0/lib/twitter/streaming/connection.rb:16:in `new'
    from /Users/gin0606/my_app/.bundle/ruby/2.2.0/gems/twitter-5.15.0/lib/twitter/streaming/connection.rb:16:in `stream'
    from /Users/gin0606/my_app/.bundle/ruby/2.2.0/gems/twitter-5.15.0/lib/twitter/streaming/client.rb:119:in `request'
    from /Users/gin0606/my_app/.bundle/ruby/2.2.0/gems/twitter-5.15.0/lib/twitter/streaming/client.rb:92:in `user'
    from /Users/gin0606/my_app/.bundle/ruby/2.2.0/gems/ruboty-twitter-0.0.8/lib/ruboty/adapters/twitter.rb:34:in `listen'
    from /Users/gin0606/my_app/.bundle/ruby/2.2.0/gems/ruboty-twitter-0.0.8/lib/ruboty/adapters/twitter.rb:19:in `run'
    from /Users/gin0606/my_app/.bundle/ruby/2.2.0/gems/ruboty-1.2.2/lib/ruboty/robot.rb:54:in `adapt'
    from /Users/gin0606/my_app/.bundle/ruby/2.2.0/gems/ruboty-1.2.2/lib/ruboty/robot.rb:22:in `run'
    from /Users/gin0606/my_app/.bundle/ruby/2.2.0/gems/ruboty-1.2.2/lib/ruboty/commands/run.rb:5:in `call'
    from /Users/gin0606/my_app/.bundle/ruby/2.2.0/gems/ruboty-1.2.2/bin/ruboty:6:in `<top (required)>'
    from /Users/gin0606/my_app/.bundle/ruby/2.2.0/bin/ruboty:23:in `load'
    from /Users/gin0606/my_app/.bundle/ruby/2.2.0/bin/ruboty:23:in `<main>'
```
# Ruby version

`ruby 2.2.2p95 (2015-04-13 revision 50295) [x86_64-darwin14]`
# bundle version

Bundler version 1.10.6
# bundle list

```
bundle list
Gems included by the bundle:
  * activesupport (4.2.5)
  * addressable (2.3.8)
  * buftok (0.2.0)
  * bundler (1.10.6)
  * domain_name (0.5.25)
  * dotenv (2.0.2)
  * equalizer (0.0.10)
  * faraday (0.9.2)
  * http (0.9.8)
  * http-cookie (1.0.2)
  * http-form_data (1.0.1)
  * http_parser.rb (0.6.0)
  * i18n (0.7.0)
  * json (1.8.3)
  * mem (0.1.5)
  * memoizable (0.4.2)
  * minitest (5.8.3)
  * multipart-post (2.0.0)
  * naught (1.1.0)
  * ruboty (1.2.2)
  * ruboty-twitter (0.0.8)
  * simple_oauth (0.3.1)
  * slop (4.2.1)
  * thread_safe (0.3.5)
  * twitter (5.15.0)
  * tzinfo (1.2.2)
  * unf (0.1.4)
  * unf_ext (0.0.7.1)
```
